### PR TITLE
Various bits & pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,35 @@ The main reason for this replacement is to get rid of the hardcoding of the
 log-format that deis-logspout uses.  Using the standard syslog format makes it
 much easier to write custom filtering etc. in deis-syslog-ng rather than trying
 to parse the custom log format of deis-logspout.
+
+
+## Setup
+
+Using logspout-etcd requires replacing some components of deis:
+
+#### deis-logger
+
+Deis logger needs to be replaced with deis-syslog-ng:
+
+    deisctl config logger set image=rolepoint/deis-syslog-ng
+    fleetctl destroy deis-logger
+    fleetctl submit units/deis-logger
+    fleetctl start deis-logger
+    fleetctl submit units/announce-syslog.service
+    fleetctl start announce-syslog.service
+
+This will setup deis-logger to use a different docker image and restart
+deis-logger with a few adjustments to the fleetctl service.  It also loads in
+the announce-syslog.service, which publishes IP & port details of the new
+deis-logger.
+
+#### deis-logspout
+
+Deis logspout needs to be replaced with logspout-etcd:
+
+    deisctl config logger set image=rolepoint/logspout-etcd
+    fleetctl stop deis-logspout
+    fleetctl start deis-logspout
+
+This is simpler, because we do not need to announce the service and do not
+need to make any customizations to the deis-logspout unit definition.

--- a/deis-syslog-ng/CHANGES.md
+++ b/deis-syslog-ng/CHANGES.md
@@ -1,0 +1,3 @@
+### v1 (12/11/15)
+
+- Initial release.  Not very tested, but basic functionality complete.

--- a/deis-syslog-ng/templates/syslog-ng.conf
+++ b/deis-syslog-ng/templates/syslog-ng.conf
@@ -37,6 +37,10 @@ log {
     filter(f_{{base $dir}});
     {{end}}
     destination(d_{{base $dir}});
+
+    {{if $data.final}}
+    flags(final);
+    {{end}}
 };
 
 {{end}}

--- a/deis-syslog-ng/templates/syslog-ng.conf
+++ b/deis-syslog-ng/templates/syslog-ng.conf
@@ -25,13 +25,17 @@ destination d_{{base $dir}} {
   tcp("{{index $url 0}}" port({{index $url 1}}) template(t_{{base $dir}}));
 };
 
+{{if ne $data.filter ""}}
 filter f_{{base $dir}} {
   {{$data.filter}}
 };
+{{end}}
 
 log {
     source(s_net);
+    {{if ne $data.filter ""}}
     filter(f_{{base $dir}});
+    {{end}}
     destination(d_{{base $dir}});
 };
 

--- a/logspout-etcd/CHANGES.md
+++ b/logspout-etcd/CHANGES.md
@@ -1,0 +1,3 @@
+### v1 (12/11/15)
+
+- Initial release of logspout with etcd config reading.

--- a/logspout-etcd/Dockerfile
+++ b/logspout-etcd/Dockerfile
@@ -1,1 +1,1 @@
-FROM gliderlabs/logspout:master
+FROM rolepoint/logspout:99b8b0a6

--- a/logspout-etcd/Dockerfile
+++ b/logspout-etcd/Dockerfile
@@ -1,1 +1,2 @@
 FROM rolepoint/logspout:99b8b0a6
+ENV SYSLOG_FORMAT=rfc3164

--- a/logspout-etcd/etcsrc/etcsrc.go
+++ b/logspout-etcd/etcsrc/etcsrc.go
@@ -73,13 +73,12 @@ func (p *EtcdSource) Run() error {
 			if !isEtcdErr {
 				return err
 			}
-			// Error code of 100 means keys are not there.  We should
-			// wait for them if this is the case.
 			if etcdErr.Code != client.ErrorCodeKeyNotFound {
 				return err
 			}
+			// Sleep for 5 secodns if the keys aren't there, then try again.
 			log.Printf("Keys %v and %v not found.  Sleeping", p.hostkey, p.portkey)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(5000 * time.Millisecond)
 		} else {
 			keysThere = true
 		}

--- a/logspout-etcd/etcsrc/etcsrc.go
+++ b/logspout-etcd/etcsrc/etcsrc.go
@@ -76,7 +76,7 @@ func (p *EtcdSource) Run() error {
 			if etcdErr.Code != client.ErrorCodeKeyNotFound {
 				return err
 			}
-			// Sleep for 5 secodns if the keys aren't there, then try again.
+			// Sleep for 5 seconds if the keys aren't there, then try again.
 			log.Printf("Keys %v and %v not found.  Sleeping", p.hostkey, p.portkey)
 			time.Sleep(5000 * time.Millisecond)
 		} else {

--- a/units/announce-syslog.service
+++ b/units/announce-syslog.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Announce syslog-ng deis-logger alternative.
+BindsTo=deis-logger.service
+After=deis-logger.service
+
+[Service]
+ExecStart=/bin/sh -c "while true; do etcdctl set /deis/logs/host %H --ttl 60; etcdctl set /deis/logs/port 514 ;sleep 45;done"
+ExecStop=/usr/bin/etcdctl rm /deis/logs/host
+
+[X-Fleet]
+MachineOf=deis-logger.service

--- a/units/deis-logger.service
+++ b/units/deis-logger.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 -e LOGSPOUT=ignore $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-logger
 Restart=on-failure
 RestartSec=5

--- a/units/deis-logger.service
+++ b/units/deis-logger.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=deis-logger
+
+[Service]
+EnvironmentFile=/etc/environment
+TimeoutStartSec=20m
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStop=-/usr/bin/docker stop deis-logger
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Added some replacement units for deis w/ documentation
- Basing things off rolepoint/logspout because I'm not 100% sure what version gliderlabs/logspout uses.
- Added some changelogs etc.
- Forcing syslog format to rfc3164, because it seems to work better with syslog-ng.
- Allow empty syslog filter so we can make catch-all logs.
- Allow log destinations to be final so we can make a log that catches un-logged messages.
- Poll on startup of etcd-logspout now polls every 5 seconds instead of 0.5 seconds.
